### PR TITLE
Support short syntax for the progress callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,25 @@ import chain from './chain';
 import {clone} from './utils';
 
 function vq(el, props, opts = null) {
+  if (!el || !props) throw new Error('Must have two or three args');
+
   if (!opts) {
+    if (!('p' in props && 'o' in props)) {
+      throw new Error('2nd arg must have `p` and `o` property when only two args is given');
+    }
+
     opts = props.o;
     props = props.p;
   }
+
+  // use `props` as progress callback if it is a function
+  if (typeof props === 'function') {
+    opts.progress = props;
+    props = {
+      tween: [1, 0]
+    };
+  }
+
   // Avoid changing original props and opts
   // vq may mutate these values internally
   props = clone(props);

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,94 @@
+import spy from './velocity-spy';
 import assert from 'power-assert';
-import index from '../src/index';
+import vq from '../src/index';
 
-describe('Index', () => {
-  it('should provide module', () => {
-    assert.deepEqual(index, {});
+describe('Index:', () => {
+  let el;
+
+  beforeEach(() => {
+    el = document.createElement('div');
+  });
+
+  describe('vq function', () => {
+    const props = { width: 300, opacity: [1, 0] };
+    const opts = { duration: 200, easing: 'easeOutQuad' };
+    const prog = function() {};
+
+    it('returns function object', () => {
+      assert(typeof vq(el, {}, {}) === 'function');
+    });
+
+    it('through parameters to the Velocity function', () => {
+      const result = spy();
+
+      vq(el, props, opts)();
+
+      const args = result.args;
+      assert(args[0] === el);
+      Object.keys(props).forEach((key) => assert(args[1][key] === props[key]));
+      Object.keys(opts).forEach((key) => assert(args[2][key] === opts[key]));
+    });
+
+    it('accepts single object format', () => {
+      const result = spy();
+
+      vq(el, { p: props, o: opts })();
+
+      const args = result.args;
+      assert(args[0] === el);
+      Object.keys(props).forEach((key) => assert(args[1][key] === props[key]));
+      Object.keys(opts).forEach((key) => assert(args[2][key] === opts[key]));
+    });
+
+    it('accepts progress function', () => {
+      const result = spy();
+
+      vq(el, prog, opts)();
+
+      // should set tween value to [1, 0]
+      assert(result.args[1].tween[0] === 1);
+      assert(result.args[1].tween[1] === 0);
+
+      assert(result.args[2].progress === prog);
+    });
+
+    it('accepts progress function as single object format', () => {
+      const result = spy();
+
+      vq(el, { p: prog, o: opts })();
+
+      // should set tween value to [1, 0]
+      assert(result.args[1].tween[0] === 1);
+      assert(result.args[1].tween[1] === 0);
+
+      assert(result.args[2].progress === prog);
+    });
+
+    it('throws an error if the arg length is less than two', () => {
+      const message = /Must have two or three args/;
+
+      assert.throws(() => {
+        vq();
+      }, message);
+
+      assert.throws(() => {
+        vq(el);
+      }, message);
+    });
+
+    it('throws an error if it receives two args and the 2nd arg is not single object format', () => {
+      assert.throws(() => {
+        vq(el, props);
+      }, /2nd arg must have `p` and `o` property when only two args is given/);
+    });
+
+    it('receives callback function to notify completion', () => {
+      const fn = function() {};
+      const result = spy();
+
+      vq(el, props, opts)(fn);
+
+      assert(result.args[2].complete === fn);
+    });
   });
 });

--- a/test/velocity-spy.js
+++ b/test/velocity-spy.js
@@ -1,0 +1,13 @@
+window.Velocity = function(...args) {
+  velocityStub.__stub.args = args;
+};
+
+function velocityStub() {
+  velocityStub.__stub = {
+    args: []
+  };
+
+  return velocityStub.__stub;
+}
+
+export default velocityStub;


### PR DESCRIPTION
This PR adds special syntax for a progress callback for #7 
Also adds some test cases.

Example:

``` js
const swing = {
  p: (el, t, r, t0, tween) => {
    const offset = 100 * Math.sin(2 * t * Math.PI);
    el[0].style.transform = `translate3d(${offset}px, 0, 0)`;
  },
  o: {
    duration: 1000,
    easing: 'easeOutCubic'
  }
}

vq(el, swing)
```
